### PR TITLE
ci: fix latent hadolint failure in Deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,40 +31,9 @@ jobs:
           echo "Workflow dispatch reason: $INPUTS_REASON"
           echo "Use test image: $INPUTS_USE_TEST_IMAGE"
 
-  hadolint:
-    name: Run hadolint against docker files
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull hadolint/hadolint:latest Image
-        run: docker pull hadolint/hadolint:latest
-      - name: Run hadolint against Dockerfiles
-        run: docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 --ignore DL3010 $(find . -type f -iname "Dockerfile*")
-
-  markdownlint:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull markdownlint/markdownlint:latest Image
-        run: docker pull markdownlint/markdownlint:latest
-      - name: Run markdownlint against *.md files
-        run: docker run --rm -i -v "$(pwd)":/workdir --workdir /workdir markdownlint/markdownlint:latest --rules ~MD013,~MD033,~MD007 $(find . -type f -iname '*.md' | grep -v '/.git/')
-
-  shellcheck:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Pull koalaman/shellcheck:stable Image
-        run: docker pull koalaman/shellcheck:stable
-      - name: Run Shellcheck against shell scripts
-        run: docker run --rm -i -v "$PWD:/mnt" koalaman/shellcheck:stable $(find . -type f -exec grep -m1 -l -E '^#!.*sh.*' {} \; | grep -v '/.git/')
-
   build_and_push:
     name: Image Build & Push
     uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@d99ce7f631ca56901a4aecca25d5c6e4b0a7e2f1 # main
-    needs: [hadolint, markdownlint, shellcheck]
     with:
       push_enabled: true
       push_destinations: ghcr.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN \
 
 FROM ghcr.io/sdr-enthusiasts/docker-baseimage:wreadsb
 
+# SMUSERNAME/SMPASSWORD are placeholder defaults that the user overrides with
+# their own sdrmap credentials at run time. Supplying them via the environment
+# is inherent to how this image is configured, so DL3064 is not actionable here.
+# hadolint ignore=DL3064
 ENV BEASTPORT=30005 \
     SMUSERNAME=yourusername \
     SMPASSWORD=yourpassword \


### PR DESCRIPTION
## Problem

Latent rather than currently visible. The last `Deploy` runs were on 2026-07-14 and both succeeded:

```text
2026-07-14T17:11  Deploy  success
2026-07-14T15:48  Deploy  success
2026-06-26T22:05  Deploy  success
```

hadolint **v2.15.0** was published on 2026-07-30T13:39:01Z, after that. Because the `hadolint` job pulled unpinned `hadolint/hadolint:latest`, the next `Deploy` — the next time `docker-baseimage` fans out — would have gone red with nothing in this repo having changed. Replaying the job's exact command against current `:latest` (2.15.1) on the unfixed Dockerfile:

```console
$ docker run --rm -i -v "$PWD":/workdir --workdir /workdir --entrypoint hadolint hadolint/hadolint \
    --ignore DL3003 --ignore DL3006 --ignore DL3010 --ignore DL4001 --ignore DL3007 \
    --ignore DL3008 --ignore SC2068 --ignore DL3007 --ignore SC1091 --ignore DL3013 \
    --ignore DL3010 $(find . -type f -iname "Dockerfile*")
./Dockerfile:25 DL3064 warning: Potentially sensitive data should not be used in the `ARG` or `ENV` commands
rc=1
```

`build_and_push` gated on all three linter jobs via `needs: [hadolint, markdownlint, shellcheck]`, so this would have **blocked the image build outright**, not merely painted the run red.

Note this repo's violation is **DL3064**, not the `DL3025`/`HEALTHCHECK` issue behind the sibling PRs — this image has no `HEALTHCHECK` at all. Same root cause (unpinned linter adopting a new rule), different rule.

## Root cause

hadolint v2.15.0 added `DL3064`, which flags `ARG`/`ENV` assignments whose **name** suggests sensitive data:

```console
$ hadolint Dockerfile     # 2.14.0, the flake.lock pin
rc=0

$ docker run --rm -i --entrypoint hadolint hadolint/hadolint:latest --no-color - < Dockerfile
-:25 DL3064 warning: Potentially sensitive data should not be used in the `ARG` or `ENV` commands
rc=1
```

`SMUSERNAME`/`SMPASSWORD` are placeholder defaults the user overrides with their own sdrmap credentials at run time. Supplying credentials through the environment is inherent to how this image is configured, so the finding is not actionable without a breaking change to the configuration interface.

## Changes

**`chore: allow DL3064 for user-supplied sdrmap credentials`** — suppressed inline, so the check stays active in every other repo:

```diff
+# SMUSERNAME/SMPASSWORD are placeholder defaults that the user overrides with
+# their own sdrmap credentials at run time. Supplying them via the environment
+# is inherent to how this image is configured, so DL3064 is not actionable here.
+# hadolint ignore=DL3064
 ENV BEASTPORT=30005 \
     SMUSERNAME=yourusername \
     SMPASSWORD=yourpassword \
```

This matches the existing inline `DL3008` pragmas already in this file at lines 5 and 35. Comment-only, so the built image is unchanged.

**`ci: drop redundant linter jobs from deploy workflow`** — removes all three unpinned jobs (`hadolint/hadolint:latest`, `markdownlint/markdownlint:latest`, `koalaman/shellcheck:stable`) and the now-dangling `needs:`.

```console
$ yq '.jobs | keys' .github/workflows/deploy.yml
- workflow-dispatch
- build_and_push
```

Removed as a **single commit** deliberately: splitting it would leave a `needs:` entry pointing at a deleted job, which is an invalid workflow and would break `git bisect`.

Coverage is unchanged — `lint.yaml` already runs all three via pre-commit against `flake.lock`-pinned versions rather than floating tags. Verified rather than assumed:

```console
"id": "hadolint"         present
"id": "markdownlint"     present
"id": "shellcheck-bash"  present
```

`check_docker` was already `true` here, so no `flake.nix` change was needed.

## Verification

hadolint clean on both the current pin and the version that broke it:

```console
$ hadolint --config <shared ruleset> Dockerfile     # 2.14.0
rc=0
$ hadolint --config <shared ruleset> Dockerfile     # 2.15.1
rc=0
```

The pragma is correctly **scoped to one instruction** and does not blanket-suppress. Adding an unrelated offending `RUN` after it still reports normally:

```console
FROM debian:trixie-slim
# hadolint ignore=DL3064
ENV SMPASSWORD=yourpassword
RUN apt-get update && apt-get install -y curl

-:4 DL3008 warning: Pin versions in apt get install...
-:4 DL3009 info: Delete the apt lists (/var/lib/apt/lists) after installing something
-:4 DL3015 info: Avoid additional packages by specifying `--no-install-recommends`
rc=1
```

Checked at **each commit individually**, not just at the tip, including a check that no commit leaves a `needs:` reference to a non-existent job:

```text
SHA       2.14.0  2.15.1  pc-hadolint  legacy-linters  dangling-needs  subject
1c153495  rc=0    rc=0    true         present         none            chore: allow DL3064 for user-supplied sdrmap credentials
39a378a4  rc=0    rc=0    true         removed         none            ci: drop redundant linter jobs from deploy workflow
```

Also checked:

- `nix develop -c pre-commit run --all-files`: green, all hooks Passed or Skipped — including `hadolint`, `markdownlint` and `shellcheck-bash`, which now carry this coverage on their own
- `docker build --platform linux/amd64`: succeeds (multi-stage, compiles stunnel from source)
- The image env is unchanged, confirming the Dockerfile edit is inert:

  ```console
  BEASTPORT=30005
  SMPASSWORD=yourpassword
  SMUSERNAME=yourusername
  ```

- `Config.Healthcheck` is `null` before and after, consistent with this image having no `HEALTHCHECK`
- No hooks bypassed; no `--no-verify`
